### PR TITLE
Demonstrates classifier problem in composite builds

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ configurations {
 
 dependencies {
     compile 'my.group:child1:1.2'
-    compile 'my.group:child2:1.2'
+    compile 'my.group:child2:1.2:foo'
 }
 
 // Use a file collection to keep track of the extracted headers and libs

--- a/child2/build.gradle
+++ b/child2/build.gradle
@@ -38,4 +38,6 @@ task archive(type: Zip) {
 
 artifacts {
     "default" file: archive.archivePath, builtBy: archive
+    // Also does not work when dependency has a 'foo' classifier
+    //"default" file: archive.archivePath, builtBy: archive, classifier: 'foo'
 }


### PR DESCRIPTION
This demonstrates the problem where adding a classifier to a dependency causes substitution to no longer match the artifact from the default configuration of the target project.